### PR TITLE
Revert "Bump alpine from 3.14.3 to 3.15.0"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM        alpine:3.15.0
+FROM        alpine:3.14.3
 
 LABEL       org.opencontainers.image.source="https://github.com/ksurl/docker-baseimage-alpine"
 


### PR DESCRIPTION
Reverts ksurl/docker-baseimage-alpine#1

no s6-overlay package available yet in alpine 3.15 repo